### PR TITLE
fix: update README and Vite config for consistent casing in URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ View your app in AI Studio: https://ai.studio/apps/drive/1ayNy1sRSL1eud9leCiXeUi
 
 ## 🌐 Live Demo
 
-**Try it now → [b2aff6009.github.io/webtreadmmill/](https://b2aff6009.github.io/webtreadmmill/)**
+**Try it now → [b2aff6009.github.io/Webtreadmmill/](https://b2aff6009.github.io/Webtreadmmill/)**
 
 ## Run Locally
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig(({ mode }) => {
       'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
     },
     // GitHub Pages serves from a subdirectory, adjust base path accordingly
-    base: mode === "production" ? "/webtreadmill/" : "/",
+    base: mode === "production" ? "/Webtreadmill/" : "/",
     resolve: {
       alias: {
         '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
Corrected the casing of the live demo link in README.md and adjusted the base path in vite.config.ts to match the updated URL structure for deployment.